### PR TITLE
Feature/remove jmbo dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
-Jmbo Composer
+Django Composer
 =============
 **Build Pages by composing listings and individual content**
 
-.. image:: https://travis-ci.org/praekelt/django-composer.svg?branch=develop
-    :target: https://travis-ci.org/praekelt/django-composer
+.. image:: https://travis-ci.org/praekelt/django-composer-prk.svg?branch=develop
+    :target: https://travis-ci.org/praekelt/django-composer-prk
 
-.. image:: https://coveralls.io/repos/github/praekelt/django-composer/badge.svg?branch=develop
-    :target: https://coveralls.io/github/praekelt/django-composer?branch=develop
+.. image:: https://coveralls.io/repos/github/praekelt/django-composer-prk/badge.svg?branch=develop
+    :target: https://coveralls.io/github/praekelt/django-composer-prk?branch=develop
 
 .. contents:: Contents
     :depth: 5
@@ -14,7 +14,7 @@ Jmbo Composer
 Installation
 ------------
 
-#. Install or add ``django-composer`` to your pip requirements.
+#. Install or add ``django-composer-prk`` to your pip requirements.
 
 #. Add ``composer`` to your ``INSTALLED_APPS`` setting.
 

--- a/composer/managers.py
+++ b/composer/managers.py
@@ -6,6 +6,7 @@ try:
     from jmbo.managers import PermittedManager as JmboPermittedManager
     has_jmbo = True
 except ImportError:
+    from django.db.models import Manager as DefaultManager
     has_jmbo = False
 
 try:

--- a/composer/managers.py
+++ b/composer/managers.py
@@ -17,7 +17,8 @@ except ImportError:
 
 
 class ComposerPermittedManager(models.Manager):
-    """Get site from request if available, otherwise default."""
+    """Get site from request if available, otherwise default.
+    """
 
     def get_queryset(self):
         queryset = super(ComposerPermittedManager, self).get_queryset()

--- a/composer/managers.py
+++ b/composer/managers.py
@@ -1,0 +1,35 @@
+from django.db import models
+from django.contrib.sites.shortcuts import get_current_site
+
+try:
+    from jmbo.managers import DefaultManager
+    from jmbo.managers import PermittedManager as JmboPermittedManager
+    has_jmbo = True
+except ImportError:
+    has_jmbo = False
+
+try:
+    from crum import get_current_request
+    has_crum = True
+except ImportError:
+    has_crum = False
+
+
+class ComposerPermittedManager(models.Manager):
+    """Get site from request if available, otherwise default."""
+
+    def get_queryset(self):
+        queryset = super(ComposerPermittedManager, self).get_queryset()
+
+        if has_crum:
+            site = get_current_site(get_current_request())
+        else:
+            site = get_current_site()
+        queryset = queryset.filter(sites__id__exact=site.id)
+
+        return queryset
+
+if has_jmbo:
+    PermittedManager = JmboPermittedManager
+else:
+    PermittedManager = ComposerPermittedManager

--- a/composer/models.py
+++ b/composer/models.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import get_script_prefix
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from jmbo.managers import DefaultManager, PermittedManager
+from .managers import DefaultManager, PermittedManager
 
 from . import SETTINGS as app_settings
 

--- a/composer/templatetags/composer_tags.py
+++ b/composer/templatetags/composer_tags.py
@@ -13,24 +13,6 @@ from jmbo.templatetags.jmbo_inclusion_tags import RenderObjectNode
 from .. import SETTINGS as app_settings
 from ..models import Row
 
-"""
-import types
-import hashlib
-import re
-
-
-from django import template
-from django.http import HttpResponse, Http404
-from django.core.paginator import Paginator, InvalidPage
-from django.contrib.sites.models import get_current_site
-
-from pagination.templatetags.pagination_tags import DEFAULT_PAGINATION, \
-    DEFAULT_ORPHANS, INVALID_PAGE_RAISES_404
-
-from foundry.models import Menu, Navbar, Listing, Page, Member
-from foundry.templatetags.listing_styles import LISTING_MAP
-"""
-
 register = template.Library()
 
 

--- a/composer/templatetags/composer_tags.py
+++ b/composer/templatetags/composer_tags.py
@@ -145,7 +145,7 @@ class TileNode(template.Node):
             # No content div found
             return html
 
-        if tile.target:
+        if tile.target is not None:
             if has_jmbo and hasattr(tile.target, "modelbase_obj"):
                 with context.push():
                     context['tile_target'] = tile.target

--- a/composer/templatetags/composer_tags.py
+++ b/composer/templatetags/composer_tags.py
@@ -8,7 +8,13 @@ from django.core.cache import cache
 from django.core.urlresolvers import NoReverseMatch, resolve, reverse
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
-from jmbo.templatetags.jmbo_inclusion_tags import RenderObjectNode
+
+# We use the special shortcut for jmbo objects
+try:
+    from jmbo.templatetags.jmbo_inclusion_tags import RenderObjectNode
+    has_jmbo = True
+except ImportError:
+    has_jmbo = False
 
 from .. import SETTINGS as app_settings
 from ..models import Row
@@ -140,8 +146,7 @@ class TileNode(template.Node):
             return html
 
         if tile.target:
-            # Use the RenderObjectNode shortcut for modelbase objects
-            if hasattr(tile.target, "modelbase_obj"):
+            if has_jmbo and hasattr(tile.target, "modelbase_obj"):
                 with context.push():
                     context['tile_target'] = tile.target
                     return RenderObjectNode("tile_target", "detail")\

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     packages = find_packages(),
     install_requires = [
         # Redundant. Pip handles this now.
-        "jmbo",
         "django-nested-admin",
         "BeautifulSoup",
     ],


### PR DESCRIPTION
This removes the dependency on Jmbo. Since Jmbo has some managers and convenience methods, this change checks for the Jmbo framework and uses it if it's part of the project, otherwise it follows the non-jmbo code paths.

The managers are copied over from Jmbo, to be used if Jmbo is not available.