### PR TITLE
Feature/issue 5 slot inherits parent folder

### DIFF
--- a/composer/context_processors.py
+++ b/composer/context_processors.py
@@ -10,16 +10,21 @@ def slots(request):
     """
 
     # TODO: caching
-    # TODO: Generalize to containing paths and/or urlconf regexes.
+    # TODO: Generalize to use urlconf regexes as well.
     url = request.path_info
-    # TODO: This can be recursively rolled up to the root url
-    url_slots = list(Slot.objects.filter(url=url))
-    # TODO: This can be cached separately, since it's the same for all urls.
-    base_slots = list(Slot.objects.filter(url="/"))
+    url_parts = [part for part in url.split("/") if part]
+    reconstructed_url = "/"
 
-    base_slots.extend(url_slots)
+    # Traverse down the url 'folder' structure, collecting slots
+    url_slots = list(Slot.objects.filter(url="/"))
+    for part in url_parts:
+        reconstructed_url += "%s/" % part
+        url_slots.extend(list(Slot.objects.filter(url=reconstructed_url)))
+
+    # Last slot (most specific url) in the url_slots list wins.
     slots = {}
-    for slot in base_slots:
+    for slot in url_slots:
         slots[slot.slot_name] = slot
 
+    print slots
     return {"composer_slots": slots}

--- a/composer/context_processors.py
+++ b/composer/context_processors.py
@@ -26,5 +26,4 @@ def slots(request):
     for slot in url_slots:
         slots[slot.slot_name] = slot
 
-    print slots
     return {"composer_slots": slots}

--- a/composer/views.py
+++ b/composer/views.py
@@ -14,7 +14,7 @@ class SlotView(DetailView):
         url = self.request.path_info
         site_id = get_current_site(self.request).id
         # TODO: Should this be permitted instead of objects?
-        page = Slot.objects.filter(url=url, sites=site_id)
+        page = Slot.objects.filter(url=url, sites=site_id, slot_name="content")
         if page:
             return page
 


### PR DESCRIPTION
Slots used to be very specific on urls: For example, if no header slot matches the current url `/post/abcde/`, it would default to the slot for `/`. This change allows the user to define a slot for `/post/` that will be shown for `/post/abcde/` too.

I also fixed a small bug where a slot on `/post/` would get rendered in the content area, even if it is a header slot.

fixes #5 