### PR TITLE
Feature/default-context

### DIFF
--- a/composer/templatetags/composer_tags.py
+++ b/composer/templatetags/composer_tags.py
@@ -60,7 +60,7 @@ class ComposerNode(template.Node):
         # Default rendering
         return render_to_string(
             "composer/inclusion_tags/%s.html" % self.slot_name,
-            context={},
+            context={"object": slot},
             request=request
         )
 

--- a/composer/tests/templates/composer/inclusion_tags/default_slot_context.html
+++ b/composer/tests/templates/composer/inclusion_tags/default_slot_context.html
@@ -1,0 +1,1 @@
+This is the default slot context title: {{ object.title }}

--- a/composer/tests/templates/tests/slot_context.html
+++ b/composer/tests/templates/tests/slot_context.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% if composer_slots %}
+    {% load composer_tags %}
+{% endif %}
+
+{% block content %}
+    Has a slot that passes default context.
+    {% if composer_slots.default_slot_context %}
+        {% composer default_slot_context %}
+    {% endif %}
+{% endblock %}

--- a/composer/tests/test_templatetags.py
+++ b/composer/tests/test_templatetags.py
@@ -213,7 +213,9 @@ class TemplateTagsContextTestCase(TestCase):
         cls.slot.save()
 
     def test_default_slot(self):
-        # Home renders the custom composer/inclusion_tags/content.html
+        # slot_context renders the custom
+        # composer/inclusion_tags/default_slot_context.html within
+        # tests/slot_context.html.
         response = self.client.get(reverse("slot_context"))
         self.assertEqual(response.context["object"], self.slot)
         self.assertHTMLEqual("""

--- a/composer/tests/test_templatetags.py
+++ b/composer/tests/test_templatetags.py
@@ -197,3 +197,32 @@ class TemplateTagsETestCase(TestCase):
         <div id="footer">
             Footer slot
         </div>""" % self.tile.id, response.content)
+
+
+class TemplateTagsContextTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TemplateTagsContextTestCase, cls).setUpTestData()
+        cls.slot = Slot.objects.create(
+            slot_name="default_slot_context",
+            url="^" + reverse("slot_context"),
+            title="test_title_for_base_slot"
+        )
+        cls.slot.sites = Site.objects.all()
+        cls.slot.save()
+
+    def test_default_slot(self):
+        # Home renders the custom composer/inclusion_tags/content.html
+        response = self.client.get(reverse("slot_context"))
+        self.assertEqual(response.context["object"], self.slot)
+        self.assertHTMLEqual("""
+        <div id="header">
+            Header slot
+        </div>
+        <div id="content">
+            Has a slot that passes default context. This is the default slot context title: test_title_for_base_slot
+        </div>
+        <div id="footer">
+            Footer slot
+        </div>""", response.content)

--- a/composer/tests/urls.py
+++ b/composer/tests/urls.py
@@ -30,4 +30,9 @@ urlpatterns = [
         TemplateView.as_view(template_name="tests/bbb.html"),
         name="bbb"
     ),
+    url(
+        r"^slot-context/$",
+        TemplateView.as_view(template_name="tests/slot_context.html"),
+        name="slot_context"
+    ),
 ]


### PR DESCRIPTION
The slot itself seemed to not be passed in context to its corresponding template, if no rows were present.